### PR TITLE
Android: Added line wrapping to slot name

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,8 +9,8 @@ import 'package:dynamic_color/dynamic_color.dart';
 import 'package:wear_bridge/wear_bridge.dart';
 import 'dart:core';
 
-const _flavor = String.fromEnvironment("edu.rit.csh.devin.flavor",
-    defaultValue: "mobile");
+const _flavor =
+    String.fromEnvironment("edu.rit.csh.devin.flavor", defaultValue: "mobile");
 
 void main() {
   runApp(const MyApp());
@@ -269,27 +269,25 @@ class _MyHomePageState extends State<MyHomePage> {
 
     return Card(
       child: ListTile(
-        title: Row(children: [
-          Text((name.length <= 15 || indexOfSpace == -1)
-              ? name
-              : "${name.substring(0, indexOfSpace)}\n${name.substring(indexOfSpace + 1)}"),
-          Expanded(
-              child: Align(
-                  alignment: Alignment.centerRight,
-                  child: InkWell(
-                      customBorder: const StadiumBorder(),
-                      onTap: () {
-                        setState(() {
-                          _usdUnit = !_usdUnit;
-                        });
-                      },
-                      child: Chip(
-                        avatar: const Icon(Icons.attach_money,
-                            semanticLabel: "Price"),
-                        label: Text(_usdUnit
-                            ? ("\$${(slot.item.price / 100).toStringAsFixed(2)}")
-                            : ("${slot.item.price.toString()} Credits")),
-                      ))))
+        title:
+            Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+          Flexible(child: Text(name)),
+          Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 10.0),
+              child: InkWell(
+                  customBorder: const StadiumBorder(),
+                  onTap: () {
+                    setState(() {
+                      _usdUnit = !_usdUnit;
+                    });
+                  },
+                  child: Chip(
+                    avatar:
+                        const Icon(Icons.attach_money, semanticLabel: "Price"),
+                    label: Text(_usdUnit
+                        ? ("\$${(slot.item.price / 100).toStringAsFixed(2)}")
+                        : ("${slot.item.price.toString()} Credits")),
+                  )))
         ]),
         subtitle: FutureBuilder<int?>(
             future: _creditCount,
@@ -300,11 +298,10 @@ class _MyHomePageState extends State<MyHomePage> {
                         alignment: Alignment.centerLeft,
                         child: ElevatedButton(
                           style: ElevatedButton.styleFrom(
-                            backgroundColor:
-                                Theme.of(context).colorScheme.primary,
-                            foregroundColor:
-                                Theme.of(context).colorScheme.onPrimary
-                          ),
+                              backgroundColor:
+                                  Theme.of(context).colorScheme.primary,
+                              foregroundColor:
+                                  Theme.of(context).colorScheme.onPrimary),
                           onPressed: ((snapshot.data == null ||
                                       snapshot.data! >= slot.item.price) &&
                                   _dropping == null)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -275,7 +275,7 @@ class _MyHomePageState extends State<MyHomePage> {
               : "${name.substring(0, indexOfSpace)}\n${name.substring(indexOfSpace + 1)}"),
           Expanded(
               child: Align(
-                  alignment: Alignment.bottomRight,
+                  alignment: Alignment.centerRight,
                   child: InkWell(
                       customBorder: const StadiumBorder(),
                       onTap: () {
@@ -305,11 +305,11 @@ class _MyHomePageState extends State<MyHomePage> {
                             foregroundColor:
                                 Theme.of(context).colorScheme.onPrimary
                           ),
-                          onPressed: !((snapshot.data == null ||
+                          onPressed: ((snapshot.data == null ||
                                       snapshot.data! >= slot.item.price) &&
                                   _dropping == null)
-                              ? null
-                              : onDrop,
+                              ? onDrop
+                              : null,
                           child: const Text('Buy Now'),
                         ))),
               ]);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -215,6 +215,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget _buildSlot(
       BuildContext context, ThinMachine machine, MachineSlot slot) {
     final icon = Icon(machine.icon, semanticLabel: machine.name);
+    final name = slot.item.name;
 
     void onDrop() {
       setState(() {
@@ -259,18 +260,22 @@ class _MyHomePageState extends State<MyHomePage> {
                     : null,
                 child: Chip(
                   avatar: icon,
-                  label: Text(slot.item.name),
+                  label: Text(name),
                 ));
           });
     }
 
+    final indexOfSpace = name.indexOf(" ");
+
     return Card(
       child: ListTile(
         title: Row(children: [
-          Text(slot.item.name),
+          Text((name.length <= 15 || indexOfSpace == -1)
+              ? name
+              : "${name.substring(0, indexOfSpace)}\n${name.substring(indexOfSpace + 1)}"),
           Expanded(
               child: Align(
-                  alignment: Alignment.centerRight,
+                  alignment: Alignment.bottomRight,
                   child: InkWell(
                       customBorder: const StadiumBorder(),
                       onTap: () {
@@ -298,13 +303,13 @@ class _MyHomePageState extends State<MyHomePage> {
                             backgroundColor:
                                 Theme.of(context).colorScheme.primary,
                             foregroundColor:
-                                Theme.of(context).colorScheme.onPrimary,
+                                Theme.of(context).colorScheme.onPrimary
                           ),
-                          onPressed: ((snapshot.data == null ||
+                          onPressed: !((snapshot.data == null ||
                                       snapshot.data! >= slot.item.price) &&
                                   _dropping == null)
-                              ? onDrop
-                              : null,
+                              ? null
+                              : onDrop,
                           child: const Text('Buy Now'),
                         ))),
               ]);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -265,8 +265,6 @@ class _MyHomePageState extends State<MyHomePage> {
           });
     }
 
-    final indexOfSpace = name.indexOf(" ");
-
     return Card(
       child: ListTile(
         title:


### PR DESCRIPTION
Sometimes the name of the slots/what's in them can cut into the display for the credit amount for that slot. This effectively cuts it off at 15 characters and creates a newline if it can find a feasible spot. *tested in Java 11*